### PR TITLE
Change entry point script name to git-reviewers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'git_reviewers=git_reviewers.reviewers:main',
+            'git-reviewers=git_reviewers.reviewers:main',
         ],
     },
 )


### PR DESCRIPTION
Git automatically uses any command named `git-X` as a extension method, allowing calling it with `git X` if the script is on PATH.

With this change, `sudo pip3 install git-reviewers` is enough to make `git reviewers` work on Ubuntu - `install.sh` is not necessary.