### PR TITLE
Optimize FindHistoricalReviewers

### DIFF
--- a/git_reviewers/reviewers.py
+++ b/git_reviewers/reviewers.py
@@ -181,7 +181,11 @@ def show_reviewers(reviewer_list, copy_clipboard):
 def get_reviewers(ignores, verbose):  # type: (List[str], bool) -> List[str]
     """ Main function to get reviewers for a repository """
     phabricator = False
-    finders = [FindLogReviewers, FindHistoricalReviewers, FindArcCommitReviewers]
+    finders = [
+        FindLogReviewers,
+        FindHistoricalReviewers,
+        FindArcCommitReviewers
+    ]
     reviewers = Counter()  # type: typing.Counter[str]
     for finder in finders:
         finder_reviewers = finder().get_reviewers()

--- a/git_reviewers/tests/test.py
+++ b/git_reviewers/tests/test.py
@@ -3,6 +3,7 @@ import os
 import json
 import sys
 import tempfile
+import typing
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -148,7 +149,8 @@ class TestHistoricalReviewers(unittest.TestCase):
 
     def test_get_reviewers(self):
         counter = Counter()  # type: typing.Counter[str]
-        self.finder.get_log_reviewers_from_file = MagicMock(return_value=counter)
+        mock_get_log_reviewers = MagicMock(return_value=counter)
+        self.finder.get_log_reviewers_from_file = mock_get_log_reviewers
         reviewers = self.finder.get_reviewers()
         self.assertEqual(counter, reviewers)
 

--- a/git_reviewers/tests/test.py
+++ b/git_reviewers/tests/test.py
@@ -141,26 +141,16 @@ class TestLogReviewers(unittest.TestCase):
         files = self.finder.get_changed_files()
         self.assertEqual(files, ['README.rst', 'setup.py'])
 
-    @patch('git_reviewers.reviewers.FindHistoricalReviewers')
-    @patch('subprocess.run')
-    def test_no_diffs(self, mock_run, mock_historical):
-        process = MagicMock()
-        process.stdout = b''
-        mock_run.return_value = process
-        mock_historical().get_changed_files.return_value = ['asdf']
-        files = self.finder.get_changed_files()
-        self.assertEqual(files, ['asdf'])
-
 
 class TestHistoricalReviewers(unittest.TestCase):
     def setUp(self):
         self.finder = reviewers.FindHistoricalReviewers()
 
-    def test_get_changed_files(self):
-        changed_files = ['README.rst', 'setup.py']
-        self.finder.run_command = MagicMock(return_value=changed_files)
-        files = self.finder.get_changed_files()
-        self.assertEqual(files, ['README.rst', 'setup.py'])
+    def test_get_reviewers(self):
+        counter = Counter()  # type: typing.Counter[str]
+        self.finder.get_log_reviewers_from_file = MagicMock(return_value=counter)
+        reviewers = self.finder.get_reviewers()
+        self.assertEqual(counter, reviewers)
 
 
 class TestFindArcCommitReviewers(unittest.TestCase):
@@ -214,13 +204,16 @@ class TestGetReviewers(unittest.TestCase):
             'git_reviewers.reviewers.'
             'FindFileLogReviewers.get_reviewers'
         )
+        run_command = 'git_reviewers.reviewers.FindReviewers.run_command'
         with patch.object(sys, 'argv', ['reviewers.py', '--verbose']):
             with patch(get_reviewers) as mock_get_reviewers:
-                with patch('subprocess.Popen') as mock_popen:
-                    mock_popen().communicate.return_value = \
-                            [PHAB_ACTIVATED_DATA, b'']
-                    mock_get_reviewers.return_value = counter
-                    reviewers.get_reviewers('', True)
+                with patch(run_command) as mock_run_command:
+                    with patch('subprocess.Popen') as mock_popen:
+                        mock_popen().communicate.return_value = \
+                                [PHAB_ACTIVATED_DATA, b'']
+                        mock_run_command.return_value = []
+                        mock_get_reviewers.return_value = counter
+                        reviewers.get_reviewers('', True)
         self.assertEqual(len(mock_print.call_args), 2)
         self.assertEqual(
             mock_print.call_args[0][0],
@@ -309,13 +302,16 @@ class TestMain(unittest.TestCase):
             'git_reviewers.reviewers.'
             'FindFileLogReviewers.get_reviewers'
         )
+        run_command = 'git_reviewers.reviewers.FindReviewers.run_command'
         with patch.object(sys, 'argv', ['reviewers.py', '-i', 'asdf']):
             with patch(get_reviewers) as mock_get_reviewers:
-                with patch('subprocess.Popen') as mock_popen:
-                    mock_popen().communicate.return_value = \
-                        [PHAB_ACTIVATED_DATA, b'']
-                    mock_get_reviewers.return_value = counter
-                    reviewers.main()
+                with patch(run_command) as mock_run_command:
+                    with patch('subprocess.Popen') as mock_popen:
+                        mock_popen().communicate.return_value = \
+                            [PHAB_ACTIVATED_DATA, b'']
+                        mock_run_command.return_value = []
+                        mock_get_reviewers.return_value = counter
+                        reviewers.main()
         self.assertEqual(mock_print.call_args[0][0], 'qwer')
 
     @patch('builtins.print')
@@ -325,11 +321,14 @@ class TestMain(unittest.TestCase):
             'git_reviewers.reviewers.'
             'FindFileLogReviewers.get_reviewers'
         )
+        run_command = 'git_reviewers.reviewers.FindReviewers.run_command'
         with patch.object(sys, 'argv', ['reviewers.py']):
             with patch(get_reviewers) as mock_get_reviewers:
-                with patch('subprocess.Popen') as mock_popen:
-                    mock_popen().communicate.return_value = \
-                        [PHAB_DISABLED_DATA, b'']
-                    mock_get_reviewers.return_value = counter
-                    reviewers.main()
+                with patch(run_command) as mock_run_command:
+                    with patch('subprocess.Popen') as mock_popen:
+                        mock_popen().communicate.return_value = \
+                            [PHAB_DISABLED_DATA, b'']
+                        mock_run_command.return_value = []
+                        mock_get_reviewers.return_value = counter
+                        reviewers.main()
         self.assertEqual(mock_print.call_args[0][0], '')


### PR DESCRIPTION
If the repository is in a clean state and git-reviewers cannot find specific files to look for reviewers, `FindHistoricalReviewers` works by listing each file in the repository and running `git shortlog -sne -- <file>` on them.  This is inefficient for large repositories.  Instead, this pull request change `FindHistoricalReviewers` to run `git shortlog -sne` on the entire repository at once making it quite a bit faster.

Fixes #40 